### PR TITLE
basic support for reboot on configurable failed unlock attempts

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -8,7 +8,10 @@
 
     <application
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name" android:allowBackup="true" android:allowClearUserData="true" android:description="@string/app_description">
+        android:label="@string/app_name"
+        android:allowBackup="true"
+        android:allowClearUserData="true"
+        android:description="@string/app_description">
         <activity
             android:name=".EncPassChangerActivity"
             android:label="@string/app_name" >
@@ -18,6 +21,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name="EncPassChangerActivity$Rebooter"
+            android:label="@string/rec_name"
+            android:description="@string/rec_description"
+            android:permission="android.permission.BIND_DEVICE_ADMIN" >
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/admin" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/README.md
+++ b/README.md
@@ -9,5 +9,9 @@ This application uses standard VDC calls to validate and set new password. I hav
 my own device (Samsung Galaxy Nexus). However, please backup you data before using this app!
 If you forget your password, you will NEVER recover your data!
 
+Additionally it supports setting a maximum number of screen unlock attempts before rebooting,
+so you can get a better compromise between encryption security and screen lock protection.
+To disable the rebooting functionality leave the attempts field empty or set it to 0. 
+
 This application may also work on Android 3, however I'm not able to test this,
 so I have set minimum API level to 15 (Android 4.0.3).

--- a/gen/com/kibab/android/EncPassChanger/R.java
+++ b/gen/com/kibab/android/EncPassChanger/R.java
@@ -11,46 +11,55 @@ public final class R {
     public static final class attr {
     }
     public static final class dimen {
-        public static final int small=0x7f040000;
+        public static final int small=0x7f050000;
     }
     public static final class drawable {
         public static final int ic_launcher=0x7f020000;
     }
     public static final class id {
-        public static final int COPYRIGHT=0x7f060009;
-        public static final int doit=0x7f060005;
-        public static final int isDebug=0x7f060007;
-        public static final int newpass=0x7f060002;
-        public static final int newpass_again=0x7f060004;
-        public static final int oldpass=0x7f060001;
-        public static final int output=0x7f060008;
-        public static final int progress=0x7f060006;
-        public static final int textView1=0x7f060000;
-        public static final int textView2=0x7f060003;
+        public static final int COPYRIGHT=0x7f07000c;
+        public static final int allowed_fails=0x7f070009;
+        public static final int button1=0x7f07000a;
+        public static final int doit=0x7f070005;
+        public static final int isDebug=0x7f070007;
+        public static final int newpass=0x7f070002;
+        public static final int newpass_again=0x7f070004;
+        public static final int oldpass=0x7f070001;
+        public static final int output=0x7f07000b;
+        public static final int progress=0x7f070006;
+        public static final int textView1=0x7f070000;
+        public static final int textView2=0x7f070003;
+        public static final int textView3=0x7f070008;
     }
     public static final class layout {
         public static final int main=0x7f030000;
     }
     public static final class string {
-        public static final int app_description=0x7f050001;
-        public static final int app_name=0x7f050000;
-        public static final int copyright=0x7f050012;
-        public static final int debuglabel=0x7f050013;
-        public static final int enc_not_enabled=0x7f05000b;
-        public static final int enc_verify_error=0x7f05000a;
-        public static final int error_when_changing=0x7f05000c;
-        public static final int exec_fail=0x7f050007;
-        public static final int go_button=0x7f050002;
-        public static final int hello=0x7f050004;
-        public static final int new_pass_incorrect=0x7f05000f;
-        public static final int newpass_not_the_same=0x7f050011;
-        public static final int pass_empty=0x7f050010;
-        public static final int pass_incorrect=0x7f05000e;
-        public static final int pass_once_again=0x7f050005;
-        public static final int password_changed=0x7f05000d;
-        public static final int su_fail=0x7f050006;
-        public static final int txt_type_old_pass=0x7f050003;
-        public static final int unk_error=0x7f050008;
-        public static final int verify_error=0x7f050009;
+        public static final int app_description=0x7f060001;
+        public static final int app_name=0x7f060000;
+        public static final int copyright=0x7f060012;
+        public static final int debuglabel=0x7f060013;
+        public static final int enc_not_enabled=0x7f06000b;
+        public static final int enc_verify_error=0x7f06000a;
+        public static final int error_when_changing=0x7f06000c;
+        public static final int exec_fail=0x7f060007;
+        public static final int go_button=0x7f060002;
+        public static final int hello=0x7f060004;
+        public static final int max_attempts=0x7f060014;
+        public static final int new_pass_incorrect=0x7f06000f;
+        public static final int newpass_not_the_same=0x7f060011;
+        public static final int pass_empty=0x7f060010;
+        public static final int pass_incorrect=0x7f06000e;
+        public static final int pass_once_again=0x7f060005;
+        public static final int password_changed=0x7f06000d;
+        public static final int rec_description=0x7f060016;
+        public static final int rec_name=0x7f060015;
+        public static final int su_fail=0x7f060006;
+        public static final int txt_type_old_pass=0x7f060003;
+        public static final int unk_error=0x7f060008;
+        public static final int verify_error=0x7f060009;
+    }
+    public static final class xml {
+        public static final int admin=0x7f040000;
     }
 }

--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -32,7 +32,7 @@
 
     <TextView
         android:id="@+id/textView2"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/pass_once_again" />
 
@@ -68,6 +68,27 @@
             android:text="@string/debuglabel" />
 
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/max_attempts" />
+
+    <EditText
+        android:id="@+id/allowed_fails"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:inputType="number"
+        android:singleLine="true" />
+
+    <Button
+        android:id="@+id/button1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:onClick="beginRebooter"
+        android:text="@string/go_button" />
 
     <EditText
         android:id="@+id/output"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -23,4 +23,8 @@
     <string name="newpass_not_the_same">Please, enter EXACT passwords in "New Password" fields!</string>
     <string name="copyright">© Kibab 2012 | http://kibab.com</string>
     <string name="debuglabel">Debug output</string>
+    
+    <string name="max_attempts">Maximum unlock attempts before reboot:</string>
+    <string name="rec_name">Rebooter</string>
+    <string name="rec_description">Allows administration for rebooting</string>
 </resources>

--- a/res/xml/admin.xml
+++ b/res/xml/admin.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <watch-login />
+        <!-- Other unused permissions for policies
+        <limit-password />
+        <reset-password />
+        <force-lock />
+        <wipe-data />
+        -->
+    </uses-policies>
+</device-admin>

--- a/src/com/kibab/android/EncPassChanger/EncPassChangerActivity.java
+++ b/src/com/kibab/android/EncPassChanger/EncPassChangerActivity.java
@@ -1,5 +1,7 @@
 package com.kibab.android.EncPassChanger;
 
+import java.io.IOException;
+
 import android.app.Activity;
 import android.os.Bundle;
 import android.view.View;
@@ -8,11 +10,23 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ProgressBar;
 
+
+import android.app.admin.DeviceAdminReceiver;
+import android.app.admin.DevicePolicyManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+
 public class EncPassChangerActivity extends Activity {
 
 	private EditText output;
 	private ProgressBar progress;
 	private CheckBox isVerbose;
+	
+	DevicePolicyManager mDPM;
+	ComponentName mAdminName;
+	int newattempts = 0;
+	static final int REQUEST_ENABLE = 15;
 
 	/** Called when the activity is first created. */
 	@Override
@@ -22,6 +36,9 @@ public class EncPassChangerActivity extends Activity {
 		output = (EditText) findViewById(R.id.output);
 		progress = (ProgressBar) findViewById(R.id.progress);
 		isVerbose = (CheckBox) findViewById(R.id.isDebug);
+		
+		mDPM = (DevicePolicyManager)getSystemService(Context.DEVICE_POLICY_SERVICE);
+		mAdminName = new ComponentName(this, Rebooter.class);
 	}
 
 	/* 'Go' button handler */
@@ -51,6 +68,7 @@ public class EncPassChangerActivity extends Activity {
 		progress.setVisibility(View.VISIBLE);
 		tsk.execute(params);
 	}
+
 	
 	/**
 	 * Used to deliver progress from background thread.
@@ -83,4 +101,97 @@ public class EncPassChangerActivity extends Activity {
 	    inputMethodManager.hideSoftInputFromWindow(getCurrentFocus().getWindowToken(), 0);
 	}
 	
+	/**
+	 * PIN go handler
+	 */
+	public void beginRebooter(View view){
+		String attemptsstring = ((EditText) findViewById(R.id.allowed_fails)).getText().toString();
+		if (attemptsstring.length() < 1) {
+			output.setText("");
+			if (mDPM.isAdminActive(mAdminName)) {
+				output.append("Disabled Rebooter administration\n" );
+				mDPM.removeActiveAdmin(mAdminName);
+			}
+		}
+		else{
+			output.setText("");
+			newattempts = Integer.parseInt(attemptsstring);
+			if (newattempts <= 0){
+				if (mDPM.isAdminActive(mAdminName)) {
+					output.append("Disabled Rebooter administration\n");
+					mDPM.removeActiveAdmin(mAdminName);
+				}	
+			}
+			else{
+				// try to get administration rights
+				Intent intent = new Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN);
+				intent.putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, mAdminName);
+				intent.putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION, "Device administration is required to be able to reboot on unlock failures");
+				startActivityForResult(intent, REQUEST_ENABLE);
+			}
+		}
+	}
+	
+	/**
+	 * Checks whether administration has been accepted for Rebooter
+	 */
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    	if (REQUEST_ENABLE == requestCode){
+	    	if (resultCode == Activity.RESULT_OK) {
+	    		// Has become the device administrator.
+	    		Rebooter.maxattempts = newattempts;
+	    		output.setText("Got admin and configured the unlock attempts to " + newattempts + "\n");
+	    	} else {
+	    		//Canceled or failed.
+	    		output.setText("Failed to get admin, unable to provide reset on unlock failures\n");
+	    	}
+    	}
+    }
+	
+	public static class Rebooter extends DeviceAdminReceiver {
+		public static int maxattempts;
+		/*
+		@Override
+		public void onDisabled(Context context, Intent intent){
+			//Called prior to the administrator being disabled, as a result of receiving ACTION_DEVICE_ADMIN_DISABLED.
+		}
+		@Override
+		public void onEnabled(Context context, Intent intent){
+			//Called after the administrator is first enabled, as a result of receiving ACTION_DEVICE_ADMIN_ENABLED.
+		}
+		@Override
+		public void onPasswordChanged(Context context, Intent intent){
+			//Called after the user has changed their password, as a result of receiving ACTION_PASSWORD_CHANGED.
+		}
+		@Override
+		public void onPasswordExpiring(Context context, Intent intent){
+			//Called periodically when the password is about to expire or has expired.
+		}
+		*/
+		@Override
+		public void onPasswordFailed(Context context, Intent intent){
+			//Called after the user has failed at entering their current password, as a result of receiving ACTION_PASSWORD_FAILED.
+	        DevicePolicyManager dpm = (DevicePolicyManager) context.getSystemService(
+	                Context.DEVICE_POLICY_SERVICE);
+			int currentattempts = dpm.getCurrentFailedPasswordAttempts();
+			if (currentattempts >= maxattempts){
+				try {
+					Runtime.getRuntime().exec("su -c reboot");
+				} catch (IOException e) {
+					//cry!
+				}
+			}
+		}
+		/*
+		@Override
+		public void onPasswordSucceeded(Context context, Intent intent){
+			//Called after the user has succeeded at entering their current password, as a result of receiving ACTION_PASSWORD_SUCCEEDED.
+		}
+		@Override
+		public void onReceive(Context context, Intent intent){
+			//Intercept standard device administrator broadcasts.
+		}
+		*/
+	}
 }


### PR DESCRIPTION
Implemented a device administration component that reboots the phone on a configurable fialed unlock attempts.

It works for me (in a nexus 4), but it needs some love in the gui and a code cleanup.
